### PR TITLE
add suport for JIT model in streaming inference

### DIFF
--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -28,6 +28,7 @@ def embed_video_clip(
     model: Videoseal, clip: np.ndarray, msgs: torch.Tensor
 ) -> np.ndarray:
     clip_tensor = torch.tensor(clip, dtype=torch.float32).permute(0, 3, 1, 2) / 255.0
+    clip_tensor = clip_tensor.to(msgs.device)
     outputs = model.embed(
         clip_tensor, msgs=msgs, is_video=True,
     )

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -38,7 +38,7 @@ def embed_video_clip(
     else:
         assert isinstance(outputs, torch.Tensor), f"Output should be a tensor, get {type(outputs)}"
         processed_clip = outputs
-    processed_clip = (processed_clip * 255.0).byte().permute(0, 2, 3, 1).numpy()
+    processed_clip = (processed_clip * 255.0).byte().permute(0, 2, 3, 1).cpu().numpy()
     return processed_clip
 
 

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -20,6 +20,10 @@ from videoseal.models import Videoseal
 from videoseal.evals.metrics import bit_accuracy
 
 
+def get_random_msg(bsz: int = 1, nbits=256) -> torch.Tensor:
+    return torch.randint(0, 2, (bsz, nbits))
+
+
 def embed_video_clip(
     model: Videoseal, clip: np.ndarray, msgs: torch.Tensor
 ) -> np.ndarray:
@@ -75,7 +79,7 @@ def embed_video(
     )
 
     # Create a random message
-    msgs = model.get_random_msg()
+    msgs = get_random_msg()
     with open(output_path.replace(".mp4", ".txt"), "w") as f:
         f.write("".join([str(msg.item()) for msg in msgs[0]]))
 

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -16,6 +16,7 @@ import torch
 import tqdm
 
 import videoseal
+from videoseal.utils.cfg import setup_model_from_checkpoint
 from videoseal.models import Videoseal
 from videoseal.evals.metrics import bit_accuracy
 
@@ -168,10 +169,14 @@ def detect_video(model: Videoseal, input_path: str, chunk_size: int) -> None:
 def main(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    video_model = videoseal.load("videoseal")
+    video_model = setup_model_from_checkpoint(args.model)
+    # video_model = videoseal.load("videoseal")
     video_model.eval()
     video_model.to(device)
-    video_model.compile()
+
+    # Compile the model if necessary (i.e. model is not already compiled or jitted)
+    if hasattr(video_model, "compile"):
+        video_model.compile()
 
     # Create the output directory and path
     os.makedirs(args.output_dir, exist_ok=True)
@@ -218,6 +223,9 @@ if __name__ == "__main__":
     import videoseal.utils as utils
 
     parser = argparse.ArgumentParser(description="Process a video with Video Seal")
+    parser.add_argument(
+        "--model", type=str, default="videoseal", help="Model name to use"
+    ) 
     parser.add_argument("--input", type=str, help="Input video path")
     parser.add_argument(
         "--output_dir", type=str, help="Output directory", default="outputs"

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -15,7 +15,6 @@ import subprocess
 import torch
 import tqdm
 
-import videoseal
 from videoseal.utils.cfg import setup_model_from_checkpoint
 from videoseal.models import Videoseal
 from videoseal.evals.metrics import bit_accuracy
@@ -178,7 +177,7 @@ def main(args):
     video_model.to(device)
 
     # Compile the model if necessary (i.e. model is not already compiled or jitted)
-    if hasattr(video_model, "compile"):
+    if not isinstance(video_model, torch.jit.ScriptModule):
         video_model.compile()
 
     # Create the output directory and path

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -169,7 +169,10 @@ def detect_video(model: Videoseal, input_path: str, chunk_size: int) -> None:
 def main(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    video_model = setup_model_from_checkpoint(args.model)
+    if args.model.endswith(".jit"):
+        video_model = torch.jit.load(args.model)
+    else:
+        video_model = setup_model_from_checkpoint(args.model)
     # video_model = videoseal.load("videoseal")
     video_model.eval()
     video_model.to(device)

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -32,7 +32,12 @@ def embed_video_clip(
     outputs = model.embed(
         clip_tensor, msgs=msgs, is_video=True,
     )
-    processed_clip = outputs["imgs_w"]
+    if not isinstance(outputs, dict):
+        assert "imgs_w" in outputs, "Output should contain 'imgs_w' key"
+        processed_clip = outputs["imgs_w"]
+    else:
+        assert isinstance(outputs, torch.Tensor), f"Output should be a tensor, get {type(outputs)}"
+        processed_clip = outputs
     processed_clip = (processed_clip * 255.0).byte().permute(0, 2, 3, 1).numpy()
     return processed_clip
 

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -32,7 +32,7 @@ def embed_video_clip(
     outputs = model.embed(
         clip_tensor, msgs=msgs, is_video=True,
     )
-    if not isinstance(outputs, dict):
+    if isinstance(outputs, dict):
         assert "imgs_w" in outputs, "Output should contain 'imgs_w' key"
         processed_clip = outputs["imgs_w"]
     else:

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -29,7 +29,7 @@ def embed_video_clip(
 ) -> np.ndarray:
     clip_tensor = torch.tensor(clip, dtype=torch.float32).permute(0, 3, 1, 2) / 255.0
     outputs = model.embed(
-        clip_tensor, msgs=msgs, is_video=True, lowres_attenuation=True
+        clip_tensor, msgs=msgs, is_video=True,
     )
     processed_clip = outputs["imgs_w"]
     processed_clip = (processed_clip * 255.0).byte().permute(0, 2, 3, 1).numpy()


### PR DESCRIPTION
## WHY ?
I changed a few lines of code in inference_stream.py to make it runnable with the newly published torchscript checkpoint @pierrefdz

## WHAT / HOW ?

- Add one more argument `model` to point to the checkpoint for streaming inference
- Expose `get_random_msg()` directly in the inference script, as this was not exported into the torchscripted model
- Consolate `compile()` to non-scripted model only
 