### PR TITLE
Adapt inference streaming for long videos

### DIFF
--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -130,9 +130,13 @@ def detect_video_clip(model: Videoseal, clip: np.ndarray, device="cpu") -> torch
     clip_tensor = torch.tensor(clip, dtype=torch.float32).permute(0, 3, 1, 2) / 255.0
     clip_tensor = clip_tensor.to(device)
     outputs = model.detect(clip_tensor, is_video=True)
-    output_bits = outputs["preds"][
-        :, 1:
-    ]  # exclude the first which may be used for detection
+    if isinstance(outputs, dict):
+        assert "preds" in outputs, "Output should contain 'preds' key"
+        # exclude the first which may be used for detection
+        output_bits = outputs["preds"][:, 1:]
+    else:
+        assert isinstance(outputs, torch.Tensor), f"Output should be a tensor, get {type(outputs)}"
+        output_bits = outputs[:, 1:]
     return output_bits
 
 

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -114,12 +114,16 @@ def embed_video(
         _pbar.update(frames_in_chunk)
         processed_frames = embed_video_clip(model, chunk[:frames_in_chunk], msgs)
         process2.stdin.write(processed_frames.tobytes())
-    
+
     _pbar.close()
 
     process1.stdout.close()
     process2.stdin.close()
-    
+    _, err1 = process1.communicate()
+    if err1:
+        print("Error during video reading:")
+        for line in process1.stderr:
+            print(line.decode("utf-8").strip())
     _, err2 = process2.communicate()
     if err2:
         print("Error during video processing:")

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -119,16 +119,6 @@ def embed_video(
 
     process1.stdout.close()
     process2.stdin.close()
-    _, err1 = process1.communicate()
-    if err1:
-        print("Error during video reading:")
-        for line in process1.stderr:
-            print(line.decode("utf-8").strip())
-    _, err2 = process2.communicate()
-    if err2:
-        print("Error during video processing:")
-        for line in process2.stderr:
-            print(line.decode("utf-8").strip())
 
     process1.wait()
     process2.wait()
@@ -241,11 +231,6 @@ def main(args):
             .overwrite_output()
             .run_async(pipe_stdout=True, pipe_stderr=False)
         )
-        _, err = process3.communicate()
-        if err:
-            print("Error copying audio:")
-            for line in process3.stderr:
-                print(line.decode("utf-8").strip())
         process3.wait()
         os.remove(temp_output)
         print("Copied audio from the original video")

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -204,7 +204,7 @@ def main(args):
         f.write("".join([str(msg.item()) for msg in msgs[0]]))
 
     # Embed the video
-    msgs_ori = embed_video(video_model, msgs, args.input, args.output, 16, device=device)
+    msgs_ori = embed_video(video_model, msgs, args.input, args.output, 16)
     print(f"Saved watermarked video to {args.output}")
 
     # Detect the watermark in the video

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -79,7 +79,7 @@ def embed_video(
             s="{}x{}".format(width, height),
             r=fps,
         )
-        .output(output_path, vcodec="libx264", pix_fmt="yuv420p", r=fps)
+        .output(output_path, vcodec=codec, pix_fmt="yuv420p", r=fps)
         .overwrite_output()
         .run_async(pipe_stdin=True, pipe_stderr=subprocess.PIPE)
     )

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -216,35 +216,35 @@ def main(args):
     bit_acc = bit_accuracy(soft_msgs, msgs_ori).item() * 100
     print(f"Binary message extracted with {bit_acc:.1f}% bit accuracy")
 
-    if args.do_audio:
-        # Placeholder to do audio watermarking as well
-        pass
-    else:
-        # Copy just the audio from the original video
-        temp_output = args.output + ".tmp"
-        os.rename(args.output, temp_output)
+    # if args.do_audio:
+    #     # Placeholder to do audio watermarking as well
+    #     pass
+    # else:
+    #     # Copy just the audio from the original video
+    #     temp_output = args.output + ".tmp"
+    #     os.rename(args.output, temp_output)
 
-        audiostream = ffmpeg.input(args.input)
-        videostream = ffmpeg.input(temp_output)
-        process3 = (
-            ffmpeg.output(
-                videostream.video,
-                audiostream.audio,
-                args.output,
-                vcodec="copy",
-                acodec="copy",
-            )
-            .overwrite_output()
-            .run_async(pipe_stderr=subprocess.PIPE)
-        )
-        _, err = process3.communicate()
-        if err:
-            print("Error copying audio:")
-            for line in process3.stderr:
-                print(line.decode("utf-8").strip())
-        process3.wait()
-        os.remove(temp_output)
-        print("Copied audio from the original video")
+    #     audiostream = ffmpeg.input(args.input)
+    #     videostream = ffmpeg.input(temp_output)
+    #     process3 = (
+    #         ffmpeg.output(
+    #             videostream.video,
+    #             audiostream.audio,
+    #             args.output,
+    #             vcodec="copy",
+    #             acodec="copy",
+    #         )
+    #         .overwrite_output()
+    #         .run_async(pipe_stderr=subprocess.PIPE)
+    #     )
+    #     _, err = process3.communicate()
+    #     if err:
+    #         print("Error copying audio:")
+    #         for line in process3.stderr:
+    #             print(line.decode("utf-8").strip())
+    #     process3.wait()
+    #     os.remove(temp_output)
+    #     print("Copied audio from the original video")
 
 
 if __name__ == "__main__":

--- a/inference_streaming.py
+++ b/inference_streaming.py
@@ -68,7 +68,7 @@ def embed_video(
             s="{}x{}".format(width, height),
             r=fps,
         )
-        .run_async(pipe_stdout=True, pipe_stderr=subprocess.PIPE)
+        .run_async(pipe_stdout=True, pipe_stderr=False)
     )
     # Open the output video with optimal thread usage.
     process2 = (
@@ -81,7 +81,7 @@ def embed_video(
         )
         .output(output_path, vcodec=codec, pix_fmt="yuv420p", r=fps)
         .overwrite_output()
-        .run_async(pipe_stdin=True, pipe_stderr=subprocess.PIPE)
+        .run_async(pipe_stdin=True, pipe_stderr=False)
     )
 
     # Process the video
@@ -160,7 +160,7 @@ def detect_video(model: Videoseal, input_path: str, chunk_size: int) -> None:
     process1 = (
         ffmpeg.input(input_path)
         .output("pipe:", format="rawvideo", pix_fmt="rgb24")
-        .run_async(pipe_stdout=True, pipe_stderr=subprocess.PIPE)
+        .run_async(pipe_stdout=True, pipe_stderr=False)
     )
 
     # Process the video
@@ -220,35 +220,35 @@ def main(args):
     bit_acc = bit_accuracy(soft_msgs, msgs_ori).item() * 100
     print(f"Binary message extracted with {bit_acc:.1f}% bit accuracy")
 
-    # if args.do_audio:
-    #     # Placeholder to do audio watermarking as well
-    #     pass
-    # else:
-    #     # Copy just the audio from the original video
-    #     temp_output = args.output + ".tmp"
-    #     os.rename(args.output, temp_output)
+    if args.do_audio:
+        # Placeholder to do audio watermarking as well
+        pass
+    else:
+        # Copy just the audio from the original video
+        temp_output = args.output + ".tmp"
+        os.rename(args.output, temp_output)
 
-    #     audiostream = ffmpeg.input(args.input)
-    #     videostream = ffmpeg.input(temp_output)
-    #     process3 = (
-    #         ffmpeg.output(
-    #             videostream.video,
-    #             audiostream.audio,
-    #             args.output,
-    #             vcodec="copy",
-    #             acodec="copy",
-    #         )
-    #         .overwrite_output()
-    #         .run_async(pipe_stderr=subprocess.PIPE)
-    #     )
-    #     _, err = process3.communicate()
-    #     if err:
-    #         print("Error copying audio:")
-    #         for line in process3.stderr:
-    #             print(line.decode("utf-8").strip())
-    #     process3.wait()
-    #     os.remove(temp_output)
-    #     print("Copied audio from the original video")
+        audiostream = ffmpeg.input(args.input)
+        videostream = ffmpeg.input(temp_output)
+        process3 = (
+            ffmpeg.output(
+                videostream.video,
+                audiostream.audio,
+                args.output,
+                vcodec="copy",
+                acodec="copy",
+            )
+            .overwrite_output()
+            .run_async(pipe_stdout=True, pipe_stderr=False)
+        )
+        _, err = process3.communicate()
+        if err:
+            print("Error copying audio:")
+            for line in process3.stderr:
+                print(line.decode("utf-8").strip())
+        process3.wait()
+        os.remove(temp_output)
+        print("Copied audio from the original video")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## WHY ?

Adapt the script `inference_streaming.py` to watermark long videos using the latest JIT checkpoint:

- Fix small issues in device mismatch when detection on CUDA
- Fix output format of detection using JIT checkpoint (the old checkpoint returns result as a dictionary, while the new JIT checkpoint returns a Tensor directly)
- For long videos, stdout / stderr can be flooded with info and warning messages, making ffmpeg subprocess stuck. By forcing them to all output to stdout and turn off the PIPE subsprocess, we can clear the bottleneck in closing the input / output stream.