### PR TITLE
Temporal Pooling for Faster Video Watermarking

### DIFF
--- a/videoseal/evals/full.py
+++ b/videoseal/evals/full.py
@@ -283,6 +283,10 @@ def main():
                         help='The number of frames to propagate the watermark to')
     group.add_argument('--videoseal_mode', type=str, default='repeat', 
                         help='The inference mode for videos')
+    group.add_argument('--time_pooling_depth', type=int, default=None,
+                        help='The depth of the UNet at which to apply temporal pooling. '
+                             'When set, enables temporal pooling which reduces frames processed '
+                             'in deeper UNet layers for faster inference.')
 
     group = parser.add_argument_group('Experiment')
     group.add_argument("--output_dir", type=str, default="outputs/", help="Output directory for logs and images (Default: /output)")
@@ -319,6 +323,20 @@ def main():
     model.step_size = args.videoseal_step_size or model.step_size
     model.video_mode = args.videoseal_mode or model.mode
     model.img_size = args.img_size_proc or model.img_size
+
+    # Override temporal pooling settings on the embedder's UNet.
+    # When time_pooling is enabled, frames are pooled at a specific UNet depth,
+    # reducing computation by processing fewer frames through deeper layers.
+    # The kernel_size is set to step_size, and step_size is then set to 1
+    # since the temporal pooling handles the frame aggregation instead.
+    if hasattr(model, 'embedder') and hasattr(model.embedder, 'unet') and hasattr(model.embedder.unet, 'time_pooling'):
+        if args.time_pooling_depth is not None:
+            model.embedder.unet.time_pooling = True
+            model.embedder.unet.time_pooling_depth = args.time_pooling_depth
+            model.embedder.unet.temporal_pool.kernel_size = model.step_size
+            # When using temporal pooling, step_size becomes 1 since
+            # frame aggregation is handled by the temporal pooling layer.
+            model.step_size = 1
 
     # Setup the device
     avail_device = 'cuda' if torch.cuda.is_available() else 'cpu'

--- a/videoseal/tests/__init__.py
+++ b/videoseal/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/videoseal/tests/test_videoseal_temporal.py
+++ b/videoseal/tests/test_videoseal_temporal.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Test temporal pooling with trained videoseal model.
+Verifies that temporal pooling doesn't break detection accuracy.
+
+Run with:
+    python -m videoseal.tests.test_videoseal_temporal
+"""
+
+import copy
+import torch
+import torchvision
+import unittest
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+import videoseal
+from videoseal.evals.metrics import bit_accuracy
+
+
+class TestTemporalPooling(unittest.TestCase):
+    """Test temporal pooling with trained pixelseal model on real video."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Load trained model and video once."""
+        cls.model = videoseal.load("pixelseal")
+        cls.model.eval()
+        cls.nbits = cls.model.embedder.msg_processor.nbits
+        
+        # Load video from assets using torchvision
+        video_path = Path(__file__).parent.parent.parent / "assets" / "videos" / "1.mp4"
+        video, _, _ = torchvision.io.read_video(str(video_path))
+        cls.video = video.permute(0, 3, 1, 2).float() / 255.0
+        cls.video = cls.video[:16]  # Use first 16 frames
+        
+        print(f"\nLoaded pixelseal model with {cls.nbits} bits")
+        print(f"Video shape: {cls.video.shape} (frames, C, H, W)")
+        print(f"Default video_mode: {cls.model.video_mode}")
+        print(f"Default step_size: {cls.model.step_size}")
+
+    def _get_accuracy(self, model, video, msg):
+        """Helper to embed, detect, and return per-frame accuracy."""
+        with torch.no_grad():
+            outputs = model.embed(video, msg, is_video=True)
+            preds = model.detect(outputs["imgs_w"], is_video=True)
+        
+        pred_msgs = preds["preds"][:, 1:]  # Skip detection bit
+        per_frame = [bit_accuracy(pred_msgs[i:i+1], msg).item() for i in range(video.shape[0])]
+        return per_frame, sum(per_frame) / len(per_frame)
+
+    def test_baseline_step_size_1(self):
+        """Baseline: step_size=1 (watermark every frame)."""
+        print("\n--- Baseline: step_size=1 ---")
+        model = copy.deepcopy(self.model)
+        model.step_size = 1
+        model.eval()
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        
+        _, acc = self._get_accuracy(model, self.video, msg)
+        print(f"  Bit accuracy: {acc*100:.1f}%")
+        
+        self.assertGreater(acc, 0.95, f"Expected >95% accuracy, got {acc*100:.1f}%")
+
+    def test_temporal_pooling_step_size_1(self):
+        """Temporal pooling with step_size=1."""
+        print("\n--- Temporal Pooling: step_size=1 ---")
+        model = copy.deepcopy(self.model)
+        model.step_size = 1
+        model.embedder.time_pooling = True
+        model.embedder.time_pooling_depth = 1
+        model.embedder.time_pooling_kernel_size = 2
+        model.embedder.time_pooling_stride = 2
+        model.eval()
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        
+        _, acc = self._get_accuracy(model, self.video, msg)
+        print(f"  Bit accuracy: {acc*100:.1f}%")
+        
+        self.assertGreater(acc, 0.95, f"Expected >95% accuracy, got {acc*100:.1f}%")
+
+    def test_video_mode_comparison(self):
+        """Compare video_modes with step_size=4."""
+        print("\n--- Video Mode Comparison (step_size=4) ---")
+        print(f"{'Mode':<15} {'Mean Acc':>10}")
+        print("-" * 27)
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        results = {}
+        
+        for video_mode in ["repeat", "alternate", "interpolate"]:
+            model = copy.deepcopy(self.model)
+            model.step_size = 4
+            model.video_mode = video_mode
+            model.eval()
+            
+            _, acc = self._get_accuracy(model, self.video, msg)
+            results[video_mode] = acc
+            print(f"{video_mode:<15} {acc*100:>9.1f}%")
+        
+        # "repeat" should have highest accuracy
+        self.assertGreater(results["repeat"], results["alternate"],
+            "repeat mode should beat alternate mode")
+
+    def test_step_size_with_repeat_mode(self):
+        """Test step_size effect with video_mode='repeat'."""
+        print("\n--- Step Size Effect (video_mode='repeat') ---")
+        print(f"{'Step Size':<12} {'Mean Acc':>10}")
+        print("-" * 24)
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        results = {}
+        
+        for step_size in [1, 2, 4, 8]:
+            model = copy.deepcopy(self.model)
+            model.step_size = step_size
+            model.video_mode = "repeat"
+            model.eval()
+            
+            _, acc = self._get_accuracy(model, self.video, msg)
+            results[step_size] = acc
+            print(f"{step_size:<12} {acc*100:>9.1f}%")
+        
+        # With repeat mode, accuracy drops with step_size but stays >70%
+        for step, acc in results.items():
+            self.assertGreater(acc, 0.70, f"step={step} too low: {acc*100:.1f}%")
+
+    def test_temporal_pooling_with_step_size(self):
+        """Test temporal pooling combined with different step sizes."""
+        print("\n--- Temporal Pooling + Step Size + Video Mode ---")
+        print(f"{'Step':<6} {'TP':>6} {'Mode':<12} {'Mean Acc':>10}")
+        print("-" * 38)
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        results = []
+        
+        configs = [
+            {"step": 1, "tp": False, "mode": "repeat"},
+            {"step": 1, "tp": True, "mode": "repeat"},
+            {"step": 4, "tp": False, "mode": "repeat"},
+            {"step": 4, "tp": True, "mode": "repeat"},
+            {"step": 4, "tp": False, "mode": "alternate"},
+            {"step": 4, "tp": True, "mode": "alternate"},
+        ]
+        
+        for cfg in configs:
+            model = copy.deepcopy(self.model)
+            model.step_size = cfg["step"]
+            model.video_mode = cfg["mode"]
+            if cfg["tp"]:
+                model.embedder.time_pooling = True
+                model.embedder.time_pooling_depth = 1
+                model.embedder.time_pooling_kernel_size = 2
+                model.embedder.time_pooling_stride = 2
+            model.eval()
+            
+            per_frame, acc = self._get_accuracy(model, self.video, msg)
+            results.append({"cfg": cfg, "acc": acc, "per_frame": per_frame})
+            
+            tp_str = "Yes" if cfg["tp"] else "No"
+            print(f"{cfg['step']:<6} {tp_str:>6} {cfg['mode']:<12} {acc*100:>9.1f}%")
+        
+        # Plot comparison
+        self._plot_results(results)
+
+    def _plot_results(self, results):
+        """Generate per-frame accuracy plots: TP=False vs TP=True (repeat mode only)."""
+        fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
+        
+        # Filter for repeat mode only
+        repeat_results = [r for r in results if r['cfg']['mode'] == 'repeat']
+        
+        # Subplot 1: TP = False
+        ax = axes[0]
+        for r in repeat_results:
+            if not r['cfg']['tp']:
+                label = f"step_size={r['cfg']['step']} (mean={r['acc']*100:.1f}%)"
+                ax.plot([a*100 for a in r["per_frame"]], marker='o', markersize=5, label=label)
+        ax.set_xlabel('Frame')
+        ax.set_ylabel('Bit Accuracy (%)')
+        ax.set_title('TP = False (video_mode=repeat)')
+        ax.set_ylim(0, 105)
+        ax.legend(fontsize=9)
+        ax.grid(True, alpha=0.3)
+        
+        # Subplot 2: TP = True
+        ax = axes[1]
+        for r in repeat_results:
+            if r['cfg']['tp']:
+                label = f"step_size={r['cfg']['step']} (mean={r['acc']*100:.1f}%)"
+                ax.plot([a*100 for a in r["per_frame"]], marker='o', markersize=5, label=label)
+        ax.set_xlabel('Frame')
+        ax.set_title('TP = True (video_mode=repeat)')
+        ax.legend(fontsize=9)
+        ax.grid(True, alpha=0.3)
+        
+        plt.tight_layout()
+        output_path = Path(__file__).parent / "temporal_pooling_full_comparison.png"
+        plt.savefig(output_path, dpi=150)
+        print(f"\nPlot saved to: {output_path}")
+        plt.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/videoseal/tests/test_videoseal_temporal.py
+++ b/videoseal/tests/test_videoseal_temporal.py
@@ -5,13 +5,28 @@
 
 """
 Test temporal pooling with trained videoseal model.
-Verifies that temporal pooling doesn't break detection accuracy.
+
+There are TWO independent mechanisms for reducing frame computation:
+
+1. **step_size** (frame skipping before UNet):
+   - Only every Nth frame is processed by the embedder
+   - video_mode controls how watermarks propagate to skipped frames
+   - Example: step_size=4 means only frames 0,4,8,12 are embedded
+
+2. **temporal_pooling** (pooling inside UNet):
+   - ALL frames enter the UNet, but frames are pooled at a specific depth
+   - Reduces computation in deeper UNet layers
+   - Controlled via model.embedder.unet.time_pooling* attributes
+
+These are MUTUALLY EXCLUSIVE - when temporal_pooling is enabled,
+step_size should be set to 1 (frame skipping is disabled).
 
 Run with:
     python -m videoseal.tests.test_videoseal_temporal
 """
 
 import copy
+import time
 import torch
 import torchvision
 import unittest
@@ -22,193 +37,424 @@ import videoseal
 from videoseal.evals.metrics import bit_accuracy
 
 
-class TestTemporalPooling(unittest.TestCase):
-    """Test temporal pooling with trained pixelseal model on real video."""
+def enable_temporal_pooling(model, kernel_size=2, depth=1):
+    """
+    Enable temporal pooling on the model's UNet.
+    
+    This pools frames INSIDE the UNet at a specific depth, reducing
+    computation in deeper layers. When enabled, step_size should be 1.
+    
+    Args:
+        model: Videoseal model (will be modified in place)
+        kernel_size: Number of frames to pool together (e.g., 2 or 4)
+        depth: UNet depth at which to apply pooling
+    """
+    if hasattr(model, 'embedder') and hasattr(model.embedder, 'unet'):
+        unet = model.embedder.unet
+        if hasattr(unet, 'time_pooling'):
+            unet.time_pooling = True
+            unet.time_pooling_depth = depth
+            unet.temporal_pool.kernel_size = kernel_size
+            unet.temporal_pool.stride = kernel_size
+            # When using temporal pooling, step_size must be 1
+            model.step_size = 1
+            return True
+    return False
+
+
+class TestStepSizeFrameSkipping(unittest.TestCase):
+    """
+    Test step_size mechanism (frame skipping BEFORE UNet).
+    
+    step_size=N means only every Nth frame goes through the embedder.
+    video_mode controls how watermarks propagate to skipped frames:
+    - "repeat": copy watermark to adjacent frames
+    - "alternate": only watermark key frames, zeros elsewhere
+    - "interpolate": blend between consecutive key frames
+    """
 
     @classmethod
     def setUpClass(cls):
-        """Load trained model and video once."""
+        """Load model and video once."""
         cls.model = videoseal.load("pixelseal")
         cls.model.eval()
         cls.nbits = cls.model.embedder.msg_processor.nbits
         
-        # Load video from assets using torchvision
         video_path = Path(__file__).parent.parent.parent / "assets" / "videos" / "1.mp4"
-        video, _, _ = torchvision.io.read_video(str(video_path))
+        video, _, _ = torchvision.io.read_video(str(video_path), pts_unit='sec')
         cls.video = video.permute(0, 3, 1, 2).float() / 255.0
-        cls.video = cls.video[:16]  # Use first 16 frames
+        cls.video = cls.video[:16]  # 16 frames
         
-        print(f"\nLoaded pixelseal model with {cls.nbits} bits")
-        print(f"Video shape: {cls.video.shape} (frames, C, H, W)")
-        print(f"Default video_mode: {cls.model.video_mode}")
-        print(f"Default step_size: {cls.model.step_size}")
+        print(f"\n[StepSize Tests] Model: {cls.nbits} bits, Video: {cls.video.shape}")
 
     def _get_accuracy(self, model, video, msg):
-        """Helper to embed, detect, and return per-frame accuracy."""
+        """Embed, detect, return mean bit accuracy."""
         with torch.no_grad():
             outputs = model.embed(video, msg, is_video=True)
             preds = model.detect(outputs["imgs_w"], is_video=True)
-        
-        pred_msgs = preds["preds"][:, 1:]  # Skip detection bit
-        per_frame = [bit_accuracy(pred_msgs[i:i+1], msg).item() for i in range(video.shape[0])]
-        return per_frame, sum(per_frame) / len(per_frame)
+        pred_msgs = preds["preds"][:, 1:]
+        return bit_accuracy(pred_msgs, msg).mean().item()
 
-    def test_baseline_step_size_1(self):
-        """Baseline: step_size=1 (watermark every frame)."""
-        print("\n--- Baseline: step_size=1 ---")
+    def test_step_size_1_baseline(self):
+        """step_size=1: watermark every frame (best quality, slowest)."""
         model = copy.deepcopy(self.model)
         model.step_size = 1
+        model.video_mode = "repeat"
         model.eval()
         
         torch.manual_seed(42)
         msg = torch.randint(0, 2, (1, self.nbits)).float()
+        acc = self._get_accuracy(model, self.video, msg)
         
-        _, acc = self._get_accuracy(model, self.video, msg)
-        print(f"  Bit accuracy: {acc*100:.1f}%")
-        
-        self.assertGreater(acc, 0.95, f"Expected >95% accuracy, got {acc*100:.1f}%")
+        print(f"\n  step_size=1: {acc*100:.1f}%")
+        self.assertGreater(acc, 0.95)
 
-    def test_temporal_pooling_step_size_1(self):
-        """Temporal pooling with step_size=1."""
-        print("\n--- Temporal Pooling: step_size=1 ---")
+    def test_step_size_4_repeat(self):
+        """step_size=4 with repeat: watermark frames 0,4,8,12, copy to others."""
         model = copy.deepcopy(self.model)
-        model.step_size = 1
-        model.embedder.time_pooling = True
-        model.embedder.time_pooling_depth = 1
-        model.embedder.time_pooling_kernel_size = 2
-        model.embedder.time_pooling_stride = 2
+        model.step_size = 4
+        model.video_mode = "repeat"
         model.eval()
         
         torch.manual_seed(42)
         msg = torch.randint(0, 2, (1, self.nbits)).float()
+        acc = self._get_accuracy(model, self.video, msg)
         
-        _, acc = self._get_accuracy(model, self.video, msg)
-        print(f"  Bit accuracy: {acc*100:.1f}%")
-        
-        self.assertGreater(acc, 0.95, f"Expected >95% accuracy, got {acc*100:.1f}%")
+        print(f"\n  step_size=4, repeat: {acc*100:.1f}%")
+        self.assertGreater(acc, 0.80)
 
-    def test_video_mode_comparison(self):
-        """Compare video_modes with step_size=4."""
-        print("\n--- Video Mode Comparison (step_size=4) ---")
-        print(f"{'Mode':<15} {'Mean Acc':>10}")
-        print("-" * 27)
+    def test_video_modes_comparison(self):
+        """Compare video_mode options with step_size=4."""
+        print("\n  Video modes (step_size=4):")
         
         torch.manual_seed(42)
         msg = torch.randint(0, 2, (1, self.nbits)).float()
         results = {}
         
-        for video_mode in ["repeat", "alternate", "interpolate"]:
+        for mode in ["repeat", "alternate", "interpolate"]:
             model = copy.deepcopy(self.model)
             model.step_size = 4
-            model.video_mode = video_mode
+            model.video_mode = mode
             model.eval()
             
-            _, acc = self._get_accuracy(model, self.video, msg)
-            results[video_mode] = acc
-            print(f"{video_mode:<15} {acc*100:>9.1f}%")
+            acc = self._get_accuracy(model, self.video, msg)
+            results[mode] = acc
+            print(f"    {mode}: {acc*100:.1f}%")
         
-        # "repeat" should have highest accuracy
-        self.assertGreater(results["repeat"], results["alternate"],
-            "repeat mode should beat alternate mode")
+        # repeat should be best since watermark is on all frames
+        self.assertGreater(results["repeat"], results["alternate"])
 
-    def test_step_size_with_repeat_mode(self):
-        """Test step_size effect with video_mode='repeat'."""
-        print("\n--- Step Size Effect (video_mode='repeat') ---")
-        print(f"{'Step Size':<12} {'Mean Acc':>10}")
-        print("-" * 24)
+
+class TestTemporalPooling(unittest.TestCase):
+    """
+    Test temporal pooling mechanism (pooling INSIDE UNet).
+    
+    Temporal pooling reduces frames at a specific UNet depth:
+    - All frames enter the UNet
+    - At depth N, frames are pooled (e.g., 16 frames -> 8 frames)
+    - Deeper layers process fewer frames (faster)
+    - On upsampling, frames are expanded back
+    
+    When using temporal pooling, step_size MUST be 1.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Load model and video once."""
+        cls.model = videoseal.load("pixelseal")
+        cls.model.eval()
+        cls.nbits = cls.model.embedder.msg_processor.nbits
+        
+        video_path = Path(__file__).parent.parent.parent / "assets" / "videos" / "1.mp4"
+        video, _, _ = torchvision.io.read_video(str(video_path), pts_unit='sec')
+        cls.video = video.permute(0, 3, 1, 2).float() / 255.0
+        cls.video = cls.video[:16]  # 16 frames
+        
+        print(f"\n[Temporal Pooling Tests] Model: {cls.nbits} bits, Video: {cls.video.shape}")
+
+    def _get_accuracy(self, model, video, msg):
+        """Embed, detect, return mean bit accuracy."""
+        with torch.no_grad():
+            outputs = model.embed(video, msg, is_video=True)
+            preds = model.detect(outputs["imgs_w"], is_video=True)
+        pred_msgs = preds["preds"][:, 1:]
+        return bit_accuracy(pred_msgs, msg).mean().item()
+
+    def test_temporal_pooling_kernel_2(self):
+        """Temporal pooling with kernel_size=2 (pool every 2 frames)."""
+        model = copy.deepcopy(self.model)
+        enabled = enable_temporal_pooling(model, kernel_size=2, depth=1)
+        
+        if not enabled:
+            self.skipTest("Model doesn't support temporal pooling")
+        
+        model.eval()
         
         torch.manual_seed(42)
         msg = torch.randint(0, 2, (1, self.nbits)).float()
-        results = {}
+        acc = self._get_accuracy(model, self.video, msg)
         
+        print(f"\n  temporal_pooling kernel=2: {acc*100:.1f}%")
+        self.assertGreater(acc, 0.90)
+
+    def test_temporal_pooling_kernel_4(self):
+        """Temporal pooling with kernel_size=4 (pool every 4 frames)."""
+        model = copy.deepcopy(self.model)
+        enabled = enable_temporal_pooling(model, kernel_size=4, depth=1)
+        
+        if not enabled:
+            self.skipTest("Model doesn't support temporal pooling")
+        
+        model.eval()
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        acc = self._get_accuracy(model, self.video, msg)
+        
+        print(f"\n  temporal_pooling kernel=4: {acc*100:.1f}%")
+        self.assertGreater(acc, 0.80)
+
+    def test_temporal_pooling_vs_step_size(self):
+        """
+        Compare temporal pooling vs step_size at equivalent reduction factor.
+        
+        Both reduce computation by ~4x:
+        - step_size=4: skip 3/4 frames before UNet
+        - temporal_pooling kernel=4: pool inside UNet
+        """
+        print("\n  Comparing equivalent 4x reduction:")
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        
+        # Method 1: step_size=4 (frame skipping)
+        model1 = copy.deepcopy(self.model)
+        model1.step_size = 4
+        model1.video_mode = "repeat"
+        model1.eval()
+        acc_step = self._get_accuracy(model1, self.video, msg)
+        
+        # Method 2: temporal_pooling kernel=4
+        model2 = copy.deepcopy(self.model)
+        enabled = enable_temporal_pooling(model2, kernel_size=4, depth=1)
+        
+        if not enabled:
+            print(f"    step_size=4: {acc_step*100:.1f}%")
+            print(f"    temporal_pooling: N/A (not supported)")
+            self.skipTest("Model doesn't support temporal pooling")
+            return
+        
+        model2.eval()
+        acc_tp = self._get_accuracy(model2, self.video, msg)
+        
+        print(f"    step_size=4: {acc_step*100:.1f}%")
+        print(f"    temporal_pooling kernel=4: {acc_tp*100:.1f}%")
+        
+        # Both should achieve reasonable accuracy
+        self.assertGreater(acc_step, 0.70)
+        self.assertGreater(acc_tp, 0.70)
+
+
+class TestAccuracySpeedComparison(unittest.TestCase):
+    """
+    Compare all methods: accuracy vs speed tradeoff.
+    Generates a plot showing the Pareto frontier of methods.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Load model and video once."""
+        cls.model = videoseal.load("pixelseal")
+        cls.model.eval()
+        cls.nbits = cls.model.embedder.msg_processor.nbits
+        
+        video_path = Path(__file__).parent.parent.parent / "assets" / "videos" / "1.mp4"
+        video, _, _ = torchvision.io.read_video(str(video_path), pts_unit='sec')
+        cls.video = video.permute(0, 3, 1, 2).float() / 255.0
+        cls.video = cls.video[:16]  # 16 frames
+        
+        print(f"\n[Accuracy vs Speed] Model: {cls.nbits} bits, Video: {cls.video.shape}")
+
+    def _benchmark(self, model, video, msg, warmup=1, runs=3):
+        """Measure accuracy and embedding time."""
+        # Warmup
+        for _ in range(warmup):
+            with torch.no_grad():
+                _ = model.embed(video, msg, is_video=True)
+        
+        # Timed runs
+        times = []
+        for _ in range(runs):
+            torch.cuda.synchronize() if torch.cuda.is_available() else None
+            start = time.time()
+            with torch.no_grad():
+                outputs = model.embed(video, msg, is_video=True)
+            torch.cuda.synchronize() if torch.cuda.is_available() else None
+            times.append(time.time() - start)
+        
+        # Get accuracy
+        with torch.no_grad():
+            preds = model.detect(outputs["imgs_w"], is_video=True)
+        pred_msgs = preds["preds"][:, 1:]
+        acc = bit_accuracy(pred_msgs, msg).mean().item()
+        
+        avg_time = sum(times) / len(times)
+        ms_per_frame = (avg_time / video.shape[0]) * 1000
+        
+        return acc, ms_per_frame
+
+    def test_plot_accuracy_vs_speed(self):
+        """Generate accuracy vs speed comparison plot."""
+        print("\n  Benchmarking all configurations...")
+        
+        torch.manual_seed(42)
+        msg = torch.randint(0, 2, (1, self.nbits)).float()
+        
+        results = []
+        
+        # 1. Step size variations (frame skipping)
         for step_size in [1, 2, 4, 8]:
             model = copy.deepcopy(self.model)
             model.step_size = step_size
             model.video_mode = "repeat"
             model.eval()
             
-            _, acc = self._get_accuracy(model, self.video, msg)
-            results[step_size] = acc
-            print(f"{step_size:<12} {acc*100:>9.1f}%")
+            acc, ms = self._benchmark(model, self.video, msg)
+            results.append({
+                "method": f"step_size={step_size}",
+                "category": "step_size",
+                "acc": acc,
+                "ms_per_frame": ms,
+                "reduction": step_size
+            })
+            print(f"    step_size={step_size}: {acc*100:.1f}%, {ms:.1f} ms/frame")
         
-        # With repeat mode, accuracy drops with step_size but stays >70%
-        for step, acc in results.items():
-            self.assertGreater(acc, 0.70, f"step={step} too low: {acc*100:.1f}%")
-
-    def test_temporal_pooling_with_step_size(self):
-        """Test temporal pooling combined with different step sizes."""
-        print("\n--- Temporal Pooling + Step Size + Video Mode ---")
-        print(f"{'Step':<6} {'TP':>6} {'Mode':<12} {'Mean Acc':>10}")
-        print("-" * 38)
-        
-        torch.manual_seed(42)
-        msg = torch.randint(0, 2, (1, self.nbits)).float()
-        results = []
-        
-        configs = [
-            {"step": 1, "tp": False, "mode": "repeat"},
-            {"step": 1, "tp": True, "mode": "repeat"},
-            {"step": 4, "tp": False, "mode": "repeat"},
-            {"step": 4, "tp": True, "mode": "repeat"},
-            {"step": 4, "tp": False, "mode": "alternate"},
-            {"step": 4, "tp": True, "mode": "alternate"},
-        ]
-        
-        for cfg in configs:
+        # 2. Temporal pooling variations
+        for kernel_size in [2, 4, 8]:
             model = copy.deepcopy(self.model)
-            model.step_size = cfg["step"]
-            model.video_mode = cfg["mode"]
-            if cfg["tp"]:
-                model.embedder.time_pooling = True
-                model.embedder.time_pooling_depth = 1
-                model.embedder.time_pooling_kernel_size = 2
-                model.embedder.time_pooling_stride = 2
+            enabled = enable_temporal_pooling(model, kernel_size=kernel_size, depth=1)
+            
+            if not enabled:
+                print(f"    temporal_pooling k={kernel_size}: SKIPPED (not supported)")
+                continue
+            
+            model.eval()
+            acc, ms = self._benchmark(model, self.video, msg)
+            results.append({
+                "method": f"temp_pool k={kernel_size}",
+                "category": "temporal_pooling",
+                "acc": acc,
+                "ms_per_frame": ms,
+                "reduction": kernel_size
+            })
+            print(f"    temporal_pooling k={kernel_size}: {acc*100:.1f}%, {ms:.1f} ms/frame")
+        
+        # 3. Video mode variations with step_size=4
+        for mode in ["repeat", "alternate", "interpolate"]:
+            model = copy.deepcopy(self.model)
+            model.step_size = 4
+            model.video_mode = mode
             model.eval()
             
-            per_frame, acc = self._get_accuracy(model, self.video, msg)
-            results.append({"cfg": cfg, "acc": acc, "per_frame": per_frame})
-            
-            tp_str = "Yes" if cfg["tp"] else "No"
-            print(f"{cfg['step']:<6} {tp_str:>6} {cfg['mode']:<12} {acc*100:>9.1f}%")
+            acc, ms = self._benchmark(model, self.video, msg)
+            results.append({
+                "method": f"step=4, {mode}",
+                "category": "video_mode",
+                "acc": acc,
+                "ms_per_frame": ms,
+                "reduction": 4
+            })
+            print(f"    step_size=4, {mode}: {acc*100:.1f}%, {ms:.1f} ms/frame")
         
-        # Plot comparison
-        self._plot_results(results)
+        # Create the plot
+        self._create_plot(results)
+        
+        # Verify we have results
+        self.assertGreater(len(results), 0)
 
-    def _plot_results(self, results):
-        """Generate per-frame accuracy plots: TP=False vs TP=True (repeat mode only)."""
-        fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
+    def _create_plot(self, results):
+        """Create accuracy vs speed comparison plot."""
+        fig, axes = plt.subplots(1, 2, figsize=(14, 6))
         
-        # Filter for repeat mode only
-        repeat_results = [r for r in results if r['cfg']['mode'] == 'repeat']
+        # Color schemes
+        colors = {
+            "step_size": "#2ecc71",       # green
+            "temporal_pooling": "#3498db", # blue  
+            "video_mode": "#e74c3c"        # red
+        }
+        markers = {
+            "step_size": "o",
+            "temporal_pooling": "s",
+            "video_mode": "^"
+        }
         
-        # Subplot 1: TP = False
+        # ===== Plot 1: Accuracy vs Speed (scatter) =====
         ax = axes[0]
-        for r in repeat_results:
-            if not r['cfg']['tp']:
-                label = f"step_size={r['cfg']['step']} (mean={r['acc']*100:.1f}%)"
-                ax.plot([a*100 for a in r["per_frame"]], marker='o', markersize=5, label=label)
-        ax.set_xlabel('Frame')
-        ax.set_ylabel('Bit Accuracy (%)')
-        ax.set_title('TP = False (video_mode=repeat)')
-        ax.set_ylim(0, 105)
-        ax.legend(fontsize=9)
-        ax.grid(True, alpha=0.3)
+        for cat in ["step_size", "temporal_pooling", "video_mode"]:
+            cat_results = [r for r in results if r["category"] == cat]
+            if not cat_results:
+                continue
+            
+            x = [r["ms_per_frame"] for r in cat_results]
+            y = [r["acc"] * 100 for r in cat_results]
+            labels = [r["method"] for r in cat_results]
+            
+            ax.scatter(x, y, c=colors[cat], marker=markers[cat], s=150, 
+                      label=cat.replace("_", " ").title(), edgecolors='white', linewidths=1.5)
+            
+            # Add labels
+            for xi, yi, label in zip(x, y, labels):
+                ax.annotate(label, (xi, yi), textcoords="offset points", 
+                           xytext=(5, 5), fontsize=8, alpha=0.8)
         
-        # Subplot 2: TP = True
-        ax = axes[1]
-        for r in repeat_results:
-            if r['cfg']['tp']:
-                label = f"step_size={r['cfg']['step']} (mean={r['acc']*100:.1f}%)"
-                ax.plot([a*100 for a in r["per_frame"]], marker='o', markersize=5, label=label)
-        ax.set_xlabel('Frame')
-        ax.set_title('TP = True (video_mode=repeat)')
-        ax.legend(fontsize=9)
+        ax.set_xlabel("Time (ms/frame)", fontsize=12)
+        ax.set_ylabel("Bit Accuracy (%)", fontsize=12)
+        ax.set_title("Accuracy vs Speed Tradeoff", fontsize=14, fontweight='bold')
+        ax.legend(loc='lower right', fontsize=10)
         ax.grid(True, alpha=0.3)
+        ax.set_ylim(50, 105)
+        
+        # ===== Plot 2: Bar chart comparison =====
+        ax = axes[1]
+        
+        # Sort by accuracy
+        sorted_results = sorted(results, key=lambda x: x["acc"], reverse=True)
+        methods = [r["method"] for r in sorted_results]
+        accuracies = [r["acc"] * 100 for r in sorted_results]
+        times = [r["ms_per_frame"] for r in sorted_results]
+        bar_colors = [colors[r["category"]] for r in sorted_results]
+        
+        x_pos = range(len(methods))
+        
+        # Accuracy bars
+        bars = ax.bar(x_pos, accuracies, color=bar_colors, alpha=0.8, edgecolor='white', linewidth=1.5)
+        
+        # Add time annotations on bars
+        for i, (bar, t, acc) in enumerate(zip(bars, times, accuracies)):
+            ax.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 1,
+                   f'{t:.1f}ms', ha='center', va='bottom', fontsize=8, color='gray')
+            ax.text(bar.get_x() + bar.get_width()/2, bar.get_height()/2,
+                   f'{acc:.1f}%', ha='center', va='center', fontsize=9, 
+                   color='white', fontweight='bold')
+        
+        ax.set_xticks(x_pos)
+        ax.set_xticklabels(methods, rotation=45, ha='right', fontsize=9)
+        ax.set_ylabel("Bit Accuracy (%)", fontsize=12)
+        ax.set_title("Methods Ranked by Accuracy\n(time shown above bars)", fontsize=14, fontweight='bold')
+        ax.set_ylim(0, 115)
+        ax.axhline(y=90, color='gray', linestyle='--', alpha=0.5, label='90% threshold')
+        ax.grid(True, alpha=0.3, axis='y')
+        
+        # Add legend for categories
+        from matplotlib.patches import Patch
+        legend_elements = [Patch(facecolor=colors[cat], label=cat.replace("_", " ").title()) 
+                          for cat in colors.keys()]
+        ax.legend(handles=legend_elements, loc='upper right', fontsize=9)
         
         plt.tight_layout()
-        output_path = Path(__file__).parent / "temporal_pooling_full_comparison.png"
-        plt.savefig(output_path, dpi=150)
-        print(f"\nPlot saved to: {output_path}")
+        output_path = Path(__file__).parent / "accuracy_vs_speed_comparison.png"
+        plt.savefig(output_path, dpi=150, bbox_inches='tight')
+        print(f"\n  Plot saved to: {output_path}")
         plt.close()
 
 


### PR DESCRIPTION
This PR introduces **temporal pooling** - to speed up video watermarking inference while maintaining high accuracy, along with comprehensive tests and benchmarking. 

---

### Benchmark Results

<img width="2082" height="883" alt="image" src="https://github.com/user-attachments/assets/deb7501c-fb1d-4396-8b8e-5e531d9954a0" />

### Usage

```python
import videoseal

model = videoseal.load("videoseal")

# Enable temporal pooling
model.embedder.unet.time_pooling = True
model.embedder.unet.time_pooling_depth = 1
model.embedder.unet.temporal_pool.kernel_size = 4
model.embedder.unet.temporal_pool.stride = 4
model.step_size = 1  # Must be 1 when using temporal pooling
# When temporal pooling is enabled, `step_size` is automatically set to 1.
```

---

### Technical Details

Think of the UNet as an hourglass - it compresses images on the way down, then expands them back up.
**Without temporal pooling:** All 16 frames go through every layer → slow
**With temporal pooling:** Frames are merged partway down, so deeper (expensive) layers process fewer frames → fast

```
Input: 16 frames
    ↓
[Layer 0] ──────────────────── 16 frames
    ↓
[Layer 1] ← POOL HERE ──────── 16 → 4 frames (merge every 4)
    ↓
[Layer 2] ──────────────────── 4 frames  ← faster!
    ↓
[Bottleneck] ───────────────── 4 frames  ← faster!
    ↓
[Layer 2] ──────────────────── 4 frames
    ↓
[Layer 1] ← EXPAND HERE ────── 4 → 16 frames (repeat each 4x)
    ↓
[Layer 0] ──────────────────── 16 frames
    ↓
Output: 16 frames
```

**Why this preserves accuracy:** Early layers capture fine details per-frame. Deeper layers capture high-level features that are similar across adjacent frames—so merging them loses little information.

