### PR TITLE
Fix header copyrights

### DIFF
--- a/videoseal/data/__init__.py
+++ b/videoseal/data/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/videoseal/evals/__init__.py
+++ b/videoseal/evals/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/videoseal/losses/perceptual.py
+++ b/videoseal/losses/perceptual.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 import torch
 import torch.nn as nn
 from lpips import LPIPS

--- a/videoseal/models/wam.py
+++ b/videoseal/models/wam.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
 Test with:
     python -m videoseal.models.wam


### PR DESCRIPTION
Add missing Meta copyright headers to 4 Python files:
- videoseal/data/__init__.py
- videoseal/evals/__init__.py
- videoseal/losses/perceptual.py
- videoseal/models/wam.py